### PR TITLE
response filters, main menu item, die after ajax response

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1,7 +1,7 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
     "content-hash": "6c08162760062dba4507a24931b27fa0",

--- a/inc/OneClickDemoImport.php
+++ b/inc/OneClickDemoImport.php
@@ -138,16 +138,35 @@ class OneClickDemoImport {
 			'menu_title'  => esc_html__( 'Import Demo Data' , 'pt-ocdi' ),
 			'capability'  => 'import',
 			'menu_slug'   => 'pt-one-click-demo-import',
+			'icon_url'    => '',
+			'position'    => null
 		) );
 
-		$this->plugin_page = add_submenu_page(
-			$this->plugin_page_setup['parent_slug'],
-			$this->plugin_page_setup['page_title'],
-			$this->plugin_page_setup['menu_title'],
-			$this->plugin_page_setup['capability'],
-			$this->plugin_page_setup['menu_slug'],
-			apply_filters( 'pt-ocdi/plugin_page_display_callback_function', array( $this, 'display_plugin_page' ) )
-		);
+		/**
+		 * ability to add menu page
+		 */
+		if( false === $this->plugin_page_setup['parent_slug'] ){
+			$this->plugin_page = add_menu_page(
+				$this->plugin_page_setup['page_title'],
+				$this->plugin_page_setup['menu_title'],
+				$this->plugin_page_setup['capability'],
+				$this->plugin_page_setup['menu_slug'],
+				apply_filters( 'pt-ocdi/plugin_page_display_callback_function', array( $this, 'display_plugin_page' ) ),
+				$this->plugin_page_setup['icon_url'],
+				$this->plugin_page_setup['position']
+			);
+		} else{
+			$this->plugin_page = add_submenu_page(
+				$this->plugin_page_setup['parent_slug'],
+				$this->plugin_page_setup['page_title'],
+				$this->plugin_page_setup['menu_title'],
+				$this->plugin_page_setup['capability'],
+				$this->plugin_page_setup['menu_slug'],
+				apply_filters( 'pt-ocdi/plugin_page_display_callback_function', array( $this, 'display_plugin_page' ) )
+			);
+		}
+
+
 
 		register_importer( $this->plugin_page_setup['menu_slug'], $this->plugin_page_setup['page_title'], $this->plugin_page_setup['menu_title'], apply_filters( 'pt-ocdi/plugin_page_display_callback_function', array( $this, 'display_plugin_page' ) ) );
 	}

--- a/inc/OneClickDemoImport.php
+++ b/inc/OneClickDemoImport.php
@@ -446,6 +446,9 @@ class OneClickDemoImport {
 		}
 
 		wp_send_json( $response );
+
+		wp_die();
+
 	}
 
 

--- a/inc/OneClickDemoImport.php
+++ b/inc/OneClickDemoImport.php
@@ -145,7 +145,7 @@ class OneClickDemoImport {
 		/**
 		 * ability to add menu page
 		 */
-		if( false === $this->plugin_page_setup['parent_slug'] ){
+		if( ! $this->plugin_page_setup['parent_slug'] ){
 			$this->plugin_page = add_menu_page(
 				$this->plugin_page_setup['page_title'],
 				$this->plugin_page_setup['menu_title'],

--- a/inc/OneClickDemoImport.php
+++ b/inc/OneClickDemoImport.php
@@ -152,7 +152,7 @@ class OneClickDemoImport {
 		register_importer( $this->plugin_page_setup['menu_slug'], $this->plugin_page_setup['page_title'], $this->plugin_page_setup['menu_title'], apply_filters( 'pt-ocdi/plugin_page_display_callback_function', array( $this, 'display_plugin_page' ) ) );
 	}
 
-    
+
 	/**
 	 * Plugin page display.
 	 * Output (HTML) is in another file.
@@ -403,18 +403,18 @@ class OneClickDemoImport {
 				);
 			}
 
-			$response['message'] .= sprintf(
+			$response['message'] .= apply_filters( 'pt-ocdi/response_message_success', sprintf(
 				__( '%1$s%3$sThat\'s it, all done!%4$s%2$sThe demo import has finished. Please check your page and make sure that everything has imported correctly. If it did, you can deactivate the %3$sOne Click Demo Import%4$s plugin, because it has done its job.%5$s', 'pt-ocdi' ),
 				'<div class="notice  notice-success"><p>',
 				'<br>',
 				'<strong>',
 				'</strong>',
 				'</p></div>'
-			);
+			));
 		}
 		else {
 			$response['message'] = $this->frontend_error_messages_display() . '<br>';
-			$response['message'] .= sprintf(
+			$response['message'] .= apply_filters( 'pt-ocdi/response_message_error', sprintf(
 				__( '%1$sThe demo import has finished, but there were some import errors.%2$sMore details about the errors can be found in this %3$s%5$slog file%6$s%4$s%7$s', 'pt-ocdi' ),
 				'<div class="notice  notice-warning"><p>',
 				'<br>',
@@ -423,7 +423,7 @@ class OneClickDemoImport {
 				'<a href="' . Helpers::get_log_url( $this->log_file_path ) .'" target="_blank">',
 				'</a>',
 				'</p></div>'
-			);
+			));
 		}
 
 		wp_send_json( $response );

--- a/inc/OneClickDemoImport.php
+++ b/inc/OneClickDemoImport.php
@@ -422,27 +422,32 @@ class OneClickDemoImport {
 				);
 			}
 
-			$response['message'] .= apply_filters( 'pt-ocdi/response_message_success', sprintf(
-				__( '%1$s%3$sThat\'s it, all done!%4$s%2$sThe demo import has finished. Please check your page and make sure that everything has imported correctly. If it did, you can deactivate the %3$sOne Click Demo Import%4$s plugin, because it has done its job.%5$s', 'pt-ocdi' ),
-				'<div class="notice  notice-success"><p>',
-				'<br>',
-				'<strong>',
-				'</strong>',
-				'</p></div>'
-			));
-		}
-		else {
+			$response['message'] .= apply_filters( 'pt-ocdi/response_message_success',
+				sprintf(
+					'<div class="notice  notice-success"><p><strong>%1$s</strong><br/>',
+					apply_filters( 'pt-ocdi/response_message_success_title', esc_html__( 'That\'s it, all done!', 'pt-ocdi' ) )
+				) .
+				sprintf(
+					apply_filters( 'pt-ocdi/response_message_success_body', esc_html__( 'The demo import has finished. Please check your page and make sure that everything has imported correctly. If it did, you can deactivate the %s plugin, because it has done its job.', 'pt-ocdi' ) ) . '</p></div>',
+					'<strong>' . esc_html__( 'One Click Demo Import', 'pt-ocdi' ) . '</strong>'
+				)
+			);
+		} else {
 			$response['message'] = $this->frontend_error_messages_display() . '<br>';
-			$response['message'] .= apply_filters( 'pt-ocdi/response_message_error', sprintf(
-				__( '%1$sThe demo import has finished, but there were some import errors.%2$sMore details about the errors can be found in this %3$s%5$slog file%6$s%4$s%7$s', 'pt-ocdi' ),
-				'<div class="notice  notice-warning"><p>',
-				'<br>',
-				'<strong>',
-				'</strong>',
-				'<a href="' . Helpers::get_log_url( $this->log_file_path ) .'" target="_blank">',
-				'</a>',
-				'</p></div>'
-			));
+			$response['message'] .= apply_filters( 'pt-ocdi/response_message_error',
+				sprintf(
+					'<div class="notice  notice-warning"><p>%1$s<br/>',
+					apply_filters( 'pt-ocdi/response_message_error_title', esc_html__( 'The demo import has finished, but there were some import errors.', 'pt-ocdi' ) )
+				)
+				. sprintf(
+					apply_filters( 'pt-ocdi/response_message_error_body',
+						esc_html__( 'More details about the errors can be found in this %s', 'pt-ocdi' ),
+						Helpers::get_log_url( $this->log_file_path )
+					) . '</p></div>',
+					'<strong><a href="' . Helpers::get_log_url( $this->log_file_path ) . '" target="_blank">' . esc_html__( 'log file', 'pt-ocdi' ) . '</a></strong>'
+				)
+			);
+
 		}
 
 		wp_send_json( $response );

--- a/views/plugin-page.php
+++ b/views/plugin-page.php
@@ -40,6 +40,7 @@ do_action( 'pt-ocdi/plugin_page_header' );
 		);
 	}
 
+	do_action('pt-ocdi/plugin_intro_text_before');
 	// Start output buffer for displaying the plugin intro text.
 	ob_start();
 	?>
@@ -80,6 +81,7 @@ do_action( 'pt-ocdi/plugin_page_header' );
 
 	// Display the plugin intro text (can be replaced with custom text through the filter below).
 	echo wp_kses_post( apply_filters( 'pt-ocdi/plugin_intro_text', $plugin_intro_text ) );
+	do_action('pt-ocdi/plugin_intro_text_after');
 	?>
 
 	<?php if ( empty( $this->import_files ) ) : ?>


### PR DESCRIPTION
Hi There,

In this pull request:

- created filter hook for ajax response if someone want to override.
- if we pass `false` to `parent_slug`, we can create main menu item if required
- good practice to add `wp_die()` after ajax response
 
Hope it helps.

btw, a perfect piece for plugin and theme authors.

i am adding support for **one-click-demo-import** in my plugin https://wordpress.org/plugins/utestdrive/

This plugin is also aiming to help plugin and theme authors.

Thanks for making this plugin happen!
