### PR TITLE
Return if OCDI_Plugin class already exist.

### DIFF
--- a/one-click-demo-import.php
+++ b/one-click-demo-import.php
@@ -15,6 +15,11 @@ Text Domain: pt-ocdi
 // Block direct access to the main plugin file.
 defined( 'ABSPATH' ) or die( 'No script kiddies please!' );
 
+// Return if OCDI_Plugin class already exist.
+if( class_exists( 'OCDI_Plugin' ) ) {
+	return;
+}
+
 /**
  * Main plugin class with initialization tasks.
  */


### PR DESCRIPTION
Return if OCDI_Plugin class already exist. avoid PHP error if theme or plugin is embedded files of plugin.