### PR TITLE
Custom log path

### DIFF
--- a/inc/Helpers.php
+++ b/inc/Helpers.php
@@ -335,7 +335,13 @@ class Helpers {
 	 * @return string, path to the log file
 	 */
 	public static function get_log_path() {
-		$upload_dir  = wp_upload_dir();
+		if(getenv('WORDPRESS_PLUGIN_OCDI_LOG_PATH')){
+			$upload_dir['path'] = getenv('WORDPRESS_PLUGIN_OCDI_LOG_PATH');
+			is_dir($upload_dir['path']) || mkdir($upload_dir['path']);
+		} else {
+			$upload_dir = wp_upload_dir();
+		}
+
 		$upload_path = self::apply_filters( 'ocdi/upload_file_path', trailingslashit( $upload_dir['path'] ) );
 
 		$log_path = $upload_path . self::apply_filters( 'ocdi/log_file_prefix', 'log_file_' ) . self::$demo_import_start_time . self::apply_filters( 'ocdi/log_file_suffix_and_file_extension', '.txt' );

--- a/inc/Helpers.php
+++ b/inc/Helpers.php
@@ -346,7 +346,9 @@ class Helpers {
 
 		$log_path = $upload_path . self::apply_filters( 'ocdi/log_file_prefix', 'log_file_' ) . self::$demo_import_start_time . self::apply_filters( 'ocdi/log_file_suffix_and_file_extension', '.txt' );
 
-		self::register_file_as_media_attachment( $log_path );
+		if(!getenv('WORDPRESS_PLUGIN_OCDI_LOG_PATH')) {
+			self::register_file_as_media_attachment($log_path);
+		}
 
 		return $log_path;
 	}


### PR DESCRIPTION
I'd like to be able to specify the log path, due to these reasons:

1. A log file is not a media file. Hence, it should not be stored in the media library, I believe.
2. Log files in /uploads/[date]/ are readable to the world.