### PR TITLE
Make successful import buttons filterable

### DIFF
--- a/inc/OneClickDemoImport.php
+++ b/inc/OneClickDemoImport.php
@@ -733,4 +733,84 @@ class OneClickDemoImport {
 			wp_update_term_count_now( $terms, $tax );
 		}
 	}
+
+	/**
+	 * Get the import buttons HTML for the successful import page.
+	 *
+	 * @since {VERSION}
+	 *
+	 * @return string
+	 */
+	public function get_import_successful_buttons_html() {
+
+		/**
+		 * Filter the buttons that are displayed on the successful import page.
+		 *
+		 * @since {VERSION}
+		 *
+		 * @param array $buttons {
+		 *     Array of buttons.
+		 *
+		 *     @type string $label  Button label.
+		 *     @type string $class  Button class.
+		 *     @type string $href   Button URL.
+		 *     @type string $target Button target. Can be `_blank`, `_parent`, `_top`. Default is `_self`.
+		 * }
+		 */
+		$buttons = Helpers::apply_filters(
+			'ocdi/import_successful_buttons',
+			[
+				[
+					'label'  => __( 'Theme Settings' , 'one-click-demo-import' ),
+					'class'  => 'button button-primary button-hero',
+					'href'   => admin_url( 'customize.php' ),
+					'target' => '_blank',
+				],
+				[
+					'label'  => __( 'Visit Site' , 'one-click-demo-import' ),
+					'class'  => 'button button-primary button-hero',
+					'href'   => get_home_url(),
+					'target' => '_blank',
+				],
+			]
+		);
+
+		if ( empty( $buttons ) || ! is_array( $buttons ) ) {
+			return '';
+		}
+
+		ob_start();
+
+		foreach ( $buttons as $button ) {
+
+			if ( empty( $button['href'] ) || empty( $button['label'] ) ) {
+				continue;
+			}
+
+			$target = '_self';
+			if (
+				! empty( $button['target'] ) &&
+				in_array( strtolower( $button['target'] ), [ '_blank', '_parent', '_top' ], true )
+			) {
+				$target = $button['target'];
+			}
+
+			$class = 'button button-primary button-hero';
+			if ( ! empty( $button['class'] ) ) {
+				$class = $button['class'];
+			}
+
+			printf(
+				'<a href="%1$s" class="%2$s" target="%3$s">%4$s</a>',
+				esc_url( $button['href'] ),
+				esc_attr( $class ),
+				esc_attr( $target ),
+				esc_html( $button['label'] )
+			);
+		}
+
+		$buttons_html = ob_get_clean();
+
+		return empty( $buttons_html ) ? '' : $buttons_html;
+	}
 }

--- a/views/import.php
+++ b/views/import.php
@@ -126,8 +126,16 @@ $theme            = wp_get_theme();
 						<div class="ocdi__response  js-ocdi-ajax-response"></div>
 					</div>
 					<div class="ocdi-imported-footer">
-						<a href="<?php echo esc_url( admin_url( 'customize.php' ) ); ?>" class="button button-primary button-hero"><?php esc_html_e( 'Theme Settings' , 'one-click-demo-import' ); ?></a>
-						<a href="<?php echo esc_url( get_home_url() ); ?>" class="button button-primary button-hero"><?php esc_html_e( 'Visit Site' , 'one-click-demo-import' ); ?></a>
+						<?php echo wp_kses(
+							$this->get_import_successful_buttons_html(),
+							[
+								'a' => [
+									'href'   => [],
+									'class'  => [],
+									'target' => [],
+								],
+							]
+						); ?>
 					</div>
 				</div>
 			</div>


### PR DESCRIPTION
## Description

This PR introduces a new filter named `ocdi/import_successful_buttons`, which allows developers to add/edit the buttons displayed after the import process is successful. 

![Screenshot 2023-10-31 at 18 29 22](https://github.com/awesomemotive/one-click-demo-import/assets/5747475/56240b8e-bf75-4c8e-bef1-fcc6fc3b1781)

## Motivation

This PR fixes #239.

## Filter usage

```php
add_filter( 'ocdi/import_successful_buttons', 'test_ocdi_import_buttons' );
function test_ocdi_import_buttons( $buttons ) {

	return [
		[
			'label'  => 'Visit Theme Options',
			'href'   => add_query_arg( 'page', 'my-theme', admin_url( 'themes.php' ) ),
			'target' => '_blank',
			'class'  => 'button button-primary button-hero',
		],
		[
			'label'  => 'Request Support',
			'href'   => 'https://my-awesome-theme.com/support/',
			'target' => '_blank',
			'class'  => 'button button-primary button-hero'
		]
	];
}
```

![Screenshot 2023-10-31 at 18 39 00](https://github.com/awesomemotive/one-click-demo-import/assets/5747475/004a947e-bb87-49e2-8c17-0659572bb8df)
