### PR TITLE
Fix PHP Deprecated notice for ReduxFramework integration

### DIFF
--- a/inc/ReduxImporter.php
+++ b/inc/ReduxImporter.php
@@ -44,7 +44,12 @@ class ReduxImporter {
 
 			if ( isset( $redux_framework->args['opt_name'] ) ) {
 				// Import Redux settings.
-				$redux_framework->set_options( $redux_options_data );
+				if ( ! empty( $redux_framework->options_class ) && method_exists( $redux_framework, 'set' ) ) {
+					$redux_framework->options_class->set( $redux_options_data );
+				} else {
+					// Handle backwards compatibility.
+					$redux_framework->set_options( $redux_options_data );
+				}
 
 				// Add this message to log file.
 				$log_added = Helpers::append_to_file( /* translators: %s - the name of the Redux option. */


### PR DESCRIPTION
## Description

This PR fixes the PHP deprecated notice when importing Redux options.

```
PHP Deprecated:  Function set_options is <strong>deprecated</strong> since version 4.0.0! Use options_class->set( $value ) instead.
```

## Motivation

Fixes #277.

## Testing Procedure

1. Perform OCDI import including Redux settings import.
2. Check and you shouldn't see the PHP deprecated notice above in your logs.