### PR TITLE
Keep track of failed media imports and skip on next AJAX calls

### DIFF
--- a/inc/Helpers.php
+++ b/inc/Helpers.php
@@ -756,4 +756,39 @@ class Helpers {
 			'menu_slug'   => 'one-click-demo-import',
 		) );
 	}
+
+	/**
+	 * Get the failed attachment imports.
+	 *
+	 * @since {VERSION}
+	 *
+	 * @return mixed
+	 */
+	public static function get_failed_attachment_imports() {
+
+		return get_transient( 'ocdi_importer_data_failed_attachment_imports' );
+	}
+
+	/**
+	 * Set the failed attachment imports.
+	 *
+	 * @since {VERSION}
+	 *
+	 * @param string $attachment_url The attachment URL that was not imported.
+	 *
+	 * @return void
+	 */
+	public static function set_failed_attachment_import( $attachment_url ) {
+
+		// Get current importer transient.
+		$failed_media_imports = self::get_failed_attachment_imports();
+
+		if ( empty( $failed_media_imports ) || ! is_array( $failed_media_imports ) ) {
+			$failed_media_imports = [];
+		}
+
+		$failed_media_imports[] = $attachment_url;
+
+		set_transient( 'ocdi_importer_data_failed_attachment_imports', $failed_media_imports, HOUR_IN_SECONDS );
+	}
 }

--- a/inc/Importer.php
+++ b/inc/Importer.php
@@ -152,6 +152,11 @@ class Importer {
 	 * @return array
 	 */
 	public function new_ajax_request_maybe( $data ) {
+
+		if ( empty( $data ) ) {
+			return $data;
+		}
+
 		$time = microtime( true ) - $this->microtime;
 
 		// We should make a new ajax call, if the time is right.

--- a/inc/OneClickDemoImport.php
+++ b/inc/OneClickDemoImport.php
@@ -7,6 +7,8 @@
 
 namespace OCDI;
 
+use WP_Error;
+
 /**
  * One Click Demo Import class, so we don't have to worry about namespaces.
  */
@@ -128,8 +130,9 @@ class OneClickDemoImport {
 		add_action( 'all_admin_notices', array( $this, 'finish_notice_output_capturing' ), PHP_INT_MAX );
 		add_action( 'admin_init', array( $this, 'redirect_from_old_default_admin_page' ) );
 		add_action( 'set_object_terms', array( $this, 'add_imported_terms' ), 10, 6 );
+		add_filter( 'wxr_importer.pre_process.post', [ $this, 'skip_failed_attachment_import' ] );
+		add_action( 'wxr_importer.process_failed.post', [ $this, 'handle_failed_attachment_import' ], 10, 5 );
 	}
-
 
 	/**
 	 * Private clone method to prevent cloning of the instance of the *Singleton* instance.
@@ -138,14 +141,12 @@ class OneClickDemoImport {
 	 */
 	private function __clone() {}
 
-
 	/**
 	 * Empty unserialize method to prevent unserializing of the *Singleton* instance.
 	 *
 	 * @return void
 	 */
 	public function __wakeup() {}
-
 
 	/**
 	 * Creates the plugin page and a submenu item in WP Appearance menu.
@@ -469,6 +470,7 @@ class OneClickDemoImport {
 	private function final_response() {
 		// Delete importer data transient for current import.
 		delete_transient( 'ocdi_importer_data' );
+		delete_transient( 'ocdi_importer_data_failed_attachment_imports' );
 
 		// Display final messages (success or warning messages).
 		$response['title'] = esc_html__( 'Import Complete!', 'one-click-demo-import' );
@@ -722,6 +724,57 @@ class OneClickDemoImport {
 		}
 
 		$this->imported_terms[ $taxonomy ] = array_unique( array_merge( $this->imported_terms[ $taxonomy ], $tt_ids ) );
+	}
+
+	/**
+	 * Returns an empty array if current attachment to be imported is in the failed imports list.
+	 *
+	 * This will skip the current attachment import.
+	 *
+	 * @since {VERSION}
+	 *
+	 * @param array $data Post data to be imported.
+	 *
+	 * @return array
+	 */
+	public function skip_failed_attachment_import( $data ) {
+		// Check if failed import.
+		if (
+			! empty( $data ) &&
+			! empty( $data['post_type'] ) &&
+			$data['post_type'] === 'attachment' &&
+			! empty( $data['attachment_url'] )
+		) {
+			// Get the previously failed imports.
+			$failed_media_imports = Helpers::get_failed_attachment_imports();
+
+			if ( ! empty( $failed_media_imports ) && in_array( $data['attachment_url'], $failed_media_imports, true ) ) {
+				// If the current attachment URL is in the failed imports, then skip it.
+				return [];
+			}
+		}
+
+		return $data;
+	}
+
+	/**
+	 * Save the failed attachment import.
+	 *
+	 * @since {VERSION}
+	 *
+	 * @param WP_Error $post_id Error object.
+	 * @param array    $data Raw data imported for the post.
+	 * @param array    $meta Raw meta data, already processed.
+	 * @param array    $comments Raw comment data, already processed.
+	 * @param array    $terms Raw term data, already processed.
+	 */
+	public function handle_failed_attachment_import( $post_id, $data, $meta, $comments, $terms ) {
+
+		if ( empty( $data ) || empty( $data['post_type'] ) || $data['post_type'] !== 'attachment' ) {
+			return;
+		}
+
+		Helpers::set_failed_attachment_import( $data['attachment_url'] );
 	}
 
 	/**


### PR DESCRIPTION
## Description

This PR keeps track of the failed media imports via transient named `ocdi_importer_data_failed_attachment_imports` and skip them on the next AJAX calls to prevent an infinite loop.

## Motivation

Fixes #216.

## Testing procedure

1. Create an export the has multiple attachments.
2. Edit the content `xml` and change the attachment URLs to anything that would be invalid.
3. Use this snippet
```php
function ocdi_change_time_of_single_ajax_call() {
	return 1;
}
add_filter( 'ocdi/time_for_one_ajax_call', 'ocdi_change_time_of_single_ajax_call' );
```
4. Perform the OCDI import.
5. The import should complete with failed media imports.

<img width="1129" alt="Screenshot 2023-11-14 at 20 10 55" src="https://github.com/awesomemotive/one-click-demo-import/assets/5747475/af9f2b5c-b02d-4ebb-8ffc-c59f603a1fcb">
