### PR TITLE
Navigation block not imported properly

### DIFF
--- a/inc/OneClickDemoImport.php
+++ b/inc/OneClickDemoImport.php
@@ -812,7 +812,7 @@ class OneClickDemoImport {
 
 				$ocdi_post_nav_block[] = $post_id;
 
-				set_transient( 'ocdi_import_posts_with_nav_block', $ocdi_post_nav_block, 3 * HOUR_IN_SECONDS );
+				set_transient( 'ocdi_import_posts_with_nav_block', $ocdi_post_nav_block, HOUR_IN_SECONDS );
 			}
 		} else {
 
@@ -832,7 +832,7 @@ class OneClickDemoImport {
 				'new_menu_id'      => $post_id,
 			];
 
-			set_transient( 'ocdi_import_menu_mapping', $ocdi_menu_mapping, 3 * HOUR_IN_SECONDS );
+			set_transient( 'ocdi_import_menu_mapping', $ocdi_menu_mapping, HOUR_IN_SECONDS );
 		}
 	}
 

--- a/inc/OneClickDemoImport.php
+++ b/inc/OneClickDemoImport.php
@@ -473,6 +473,8 @@ class OneClickDemoImport {
 		// Delete importer data transient for current import.
 		delete_transient( 'ocdi_importer_data' );
 		delete_transient( 'ocdi_importer_data_failed_attachment_imports' );
+		delete_transient( 'ocdi_import_menu_mapping' );
+		delete_transient( 'ocdi_import_posts_with_nav_block' );
 
 		// Display final messages (success or warning messages).
 		$response['title'] = esc_html__( 'Import Complete!', 'one-click-demo-import' );

--- a/inc/OneClickDemoImport.php
+++ b/inc/OneClickDemoImport.php
@@ -800,6 +800,12 @@ class OneClickDemoImport {
 			return;
 		}
 
+		$replace_pairs = [];
+
+		foreach ( $nav_import_mapping as $mapping ) {
+			$replace_pairs[ '<!-- wp:navigation {"ref":' . $mapping['original_menu_id'] . '} /-->' ] = '<!-- wp:navigation {"ref":' . $mapping['new_menu_id'] . '} /-->';
+		}
+
 		// Loop through each the posts that needs to be updated.
 		foreach ( $posts_nav_block as $post_id ) {
 			$post_nav_block = get_post( $post_id );
@@ -808,21 +814,10 @@ class OneClickDemoImport {
 				return;
 			}
 
-			$new_content = $post_nav_block->post_content;
-
-			// Loop through each of the nav_import_mapping.
-			foreach ( $nav_import_mapping as $mapping ) {
-				$new_content = str_replace(
-					'<!-- wp:navigation {"ref":' . $mapping['original_menu_id'] . '} /-->',
-					'<!-- wp:navigation {"ref":' . $mapping['new_menu_id'] . '} /-->',
-					$new_content
-				);
-			}
-
 			wp_update_post(
 				[
 					'ID'           => $post_id,
-					'post_content' => $new_content,
+					'post_content' => strtr( $post_nav_block->post_content, $replace_pairs ),
 				]
 			);
 		}


### PR DESCRIPTION
## Description

This PR fixes the issue where the Navigation block isn't imported properly. The issue is happening because the menu/Post ID reference that is imported doesn't reflect the new menu/post ID after they were imported. The approach on this PR to solve the issue is to: 
1. keep track of the new Post ID of all the import items with Navigation block (by searching `<!-- wp:navigation`).
2. keep track of the original/old and new menu ID.
3. Replace the original menu ID with the new one on the posts we tracked from step 1 above.

## Motivation

Fixes #285.

## Testing procedure

1. Create a new XML export with Navigation block on different pages. Use different menus on the navigation blocks for testing.
2. Perform the OCDI import and confirm that the Navigation block is imported properly.

## Screenshots

**This is how it looks like before the PR**

<img width="552" alt="Screenshot 2023-11-16 at 23 12 06" src="https://github.com/awesomemotive/one-click-demo-import/assets/5747475/dcf789b7-628b-4b3b-bf0e-3305e31f252a">

**This is how it looks like with the fix**

<img width="697" alt="Screenshot 2023-11-16 at 23 08 04" src="https://github.com/awesomemotive/one-click-demo-import/assets/5747475/27f01fa5-64b1-4755-a29d-4f13babed9c6">
