### PR TITLE
Support since version placeholder

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -14,6 +14,8 @@ const gulp = require( 'gulp' ),
 	uglify = require( 'gulp-uglify' ),
 	copy = require( 'gulp-copy' ),
 	readme = require( 'gulp-readme-to-markdown' ),
+	replace = require( 'gulp-replace' ),
+	packageJSON = require( './package.json' ),
 	exec = require( 'child_process' ).exec;
 
 const plugin = {
@@ -64,7 +66,16 @@ const plugin = {
 	js: [
 		'assets/js/*.js',
 		'!assets/js/*.min.js',
-	]
+	],
+	files_replace_ver: [
+		"**/*.php",
+		"**/*.js",
+		"!**/*.min.js",
+		"!languages/**",
+		"!node_modules/**",
+		"!vendor/**",
+		"!gulpfile.js",
+	],
 };
 
 /**
@@ -144,6 +155,17 @@ gulp.task( 'copy', function () {
 		// } ) )
 		.pipe(copy('one-click-demo-import'))
 		.pipe( debug( { title: '[copy]' } ) );
+} );
+
+gulp.task( 'replace_since_ver', function() {
+	return gulp.src( plugin.files_replace_ver )
+		.pipe(
+			replace(
+				/@since {VERSION}/g,
+				'@since ' + packageJSON.version
+			)
+		)
+		.pipe( gulp.dest( './' ) );
 } );
 
 /**

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -157,6 +157,24 @@ gulp.task( 'copy', function () {
 		.pipe( debug( { title: '[copy]' } ) );
 } );
 
+/**
+ * Replace plugin version with one from package.json in the main plugin file.
+ */
+gulp.task( 'replace_plugin_file_ver', function () {
+	return gulp.src( [ 'one-click-demo-import.php' ] )
+		.pipe(
+			// File header.
+			replace(
+				/Version: ((\*)|([0-9]+(\.((\*)|([0-9]+(\.((\*)|([0-9]+)))?)))?))/gm,
+				'Version: ' + packageJSON.version
+			)
+		)
+		.pipe( gulp.dest( './' ) );
+} );
+
+/**
+ * Replace plugin version with one from package.json in @since comments in plugin PHP and JS files.
+ */
 gulp.task( 'replace_since_ver', function() {
 	return gulp.src( plugin.files_replace_ver )
 		.pipe(
@@ -168,10 +186,12 @@ gulp.task( 'replace_since_ver', function() {
 		.pipe( gulp.dest( './' ) );
 } );
 
+gulp.task( 'replace_ver', gulp.series( 'replace_plugin_file_ver', 'replace_since_ver' ) );
+
 /**
  * Task: build.
  */
-gulp.task( 'build', gulp.series( gulp.parallel( 'css', 'js', 'pot' ), 'copy' ) );
+gulp.task( 'build', gulp.series( gulp.parallel( 'css', 'js', 'pot' ), 'replace_ver', 'copy' ) );
 
 /**
  * Look out for relevant sass/js changes.

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "gulp-debug": "^5.0.1",
         "gulp-readme-to-markdown": "^0.2.1",
         "gulp-rename": "^2.0.0",
+        "gulp-replace": "^1.1.4",
         "gulp-sass": "^5.1.0",
         "gulp-sourcemaps": "^3.0.0",
         "gulp-uglify": "^3.0.2",
@@ -625,6 +626,18 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/binaryextensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binaryextensions/-/binaryextensions-2.3.0.tgz",
+      "integrity": "sha512-nAihlQsYGyc5Bwq6+EsubvANYGExeJKHDO3RjnvwU042fawQTQfM3Kxn7IHUXQOz4bzfwsGYYHGSvXyW4zOGLg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8"
+      },
+      "funding": {
+        "url": "https://bevry.me/fund"
       }
     },
     "node_modules/bindings": {
@@ -2587,6 +2600,22 @@
         "node": ">=4"
       }
     },
+    "node_modules/gulp-replace": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/gulp-replace/-/gulp-replace-1.1.4.tgz",
+      "integrity": "sha512-SVSF7ikuWKhpAW4l4wapAqPPSToJoiNKsbDoUnRrSgwZHH7lH8pbPeQj1aOVYQrbZKhfSVBxVW+Py7vtulRktw==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "@types/vinyl": "^2.0.4",
+        "istextorbinary": "^3.0.0",
+        "replacestream": "^4.0.3",
+        "yargs-parser": ">=5.0.0-security.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/gulp-sass": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/gulp-sass/-/gulp-sass-5.1.0.tgz",
@@ -3624,6 +3653,22 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/istextorbinary": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-3.3.0.tgz",
+      "integrity": "sha512-Tvq1W6NAcZeJ8op+Hq7tdZ434rqnMx4CCZ7H0ff83uEloDvVbqAwaMTZcafKGJT0VHkYzuXUiCY4hlXQg6WfoQ==",
+      "dev": true,
+      "dependencies": {
+        "binaryextensions": "^2.2.0",
+        "textextensions": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://bevry.me/fund"
       }
     },
     "node_modules/js-yaml": {
@@ -5471,6 +5516,26 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/replacestream": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/replacestream/-/replacestream-4.0.3.tgz",
+      "integrity": "sha512-AC0FiLS352pBBiZhd4VXB1Ab/lh0lEgpP+GGvZqbQh8a5cmXVoTe5EX/YeTFArnp4SRGTHh1qCHu9lGs1qG8sA==",
+      "dev": true,
+      "dependencies": {
+        "escape-string-regexp": "^1.0.3",
+        "object-assign": "^4.0.1",
+        "readable-stream": "^2.0.2"
+      }
+    },
+    "node_modules/replacestream/node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -6230,6 +6295,18 @@
       "dependencies": {
         "es6-iterator": "^2.0.1",
         "es6-symbol": "^3.1.1"
+      }
+    },
+    "node_modules/textextensions": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/textextensions/-/textextensions-3.3.0.tgz",
+      "integrity": "sha512-mk82dS8eRABNbeVJrEiN5/UMSCliINAuz8mkUwH4SwslkNP//gbEzlWNS5au0z5Dpx40SQxzqZevZkn+WYJ9Dw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://bevry.me/fund"
       }
     },
     "node_modules/through2": {

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "version": "3.2.0",
   "type": "module",
   "private": true,
   "devDependencies": {
@@ -9,6 +10,7 @@
     "gulp-debug": "^5.0.1",
     "gulp-readme-to-markdown": "^0.2.1",
     "gulp-rename": "^2.0.0",
+    "gulp-replace": "^1.1.4",
     "gulp-sass": "^5.1.0",
     "gulp-sourcemaps": "^3.0.0",
     "gulp-uglify": "^3.0.2",


### PR DESCRIPTION
## Description

This PR adds a new task in `gulp build` process where we replace the version in the main PHP file (`one-click-demo-import.php`) and `@since {VERSION}` to PHP and JS files with the package JSON version.

## Testing procedure

1. Run the command `npm run gulp build` in the repo's root.
2. Confirm that the `@since {VERSION}` and the main PHP file's version was updated in both the build files and our working files.